### PR TITLE
bug fix for input group sizes and not being the first or last child

### DIFF
--- a/typeahead.css
+++ b/typeahead.css
@@ -120,6 +120,10 @@ textarea.input-group.input-group-sm .twitter-typeahead .tt-hint {
 .input-group.input-group-sm .twitter-typeahead:only-child .tt-hint {
   border-radius: 3px;
 }
+.input-group.input-group-sm .twitter-typeahead:not(:first-child):not(:last-child) .tt-query,
+.input-group.input-group-sm .twitter-typeahead:not(:first-child):not(:last-child) .tt-hint {
+  border-radius: 0px;
+}
 .input-group.input-group-lg .twitter-typeahead .tt-query,
 .input-group.input-group-lg .twitter-typeahead .tt-hint {
   height: 45px;
@@ -154,6 +158,10 @@ textarea.input-group.input-group-lg .twitter-typeahead .tt-hint {
 .input-group.input-group-lg .twitter-typeahead:only-child .tt-query,
 .input-group.input-group-lg .twitter-typeahead:only-child .tt-hint {
   border-radius: 6px;
+}
+.input-group.input-group-lg .twitter-typeahead:not(:first-child):not(:last-child) .tt-query,
+.input-group.input-group-lg .twitter-typeahead:not(:first-child):not(:last-child) .tt-hint {
+  border-radius: 0px;
 }
 .twitter-typeahead {
   width: 100%;

--- a/typeahead.less
+++ b/typeahead.less
@@ -68,6 +68,9 @@
   .input-group.input-group-sm .twitter-typeahead:only-child &{
     border-radius:@border-radius-small;
   }
+  .input-group.input-group-sm .twitter-typeahead:not(:first-child):not(:last-child) &{
+    border-radius: 0px;
+  }
 
   //sizing - large:size and border
   .input-group.input-group-lg .twitter-typeahead &{
@@ -83,6 +86,9 @@
   }
   .input-group.input-group-lg .twitter-typeahead:only-child &{
     border-radius:@border-radius-large;
+  }
+  .input-group.input-group-lg .twitter-typeahead:not(:first-child):not(:last-child) &{
+    border-radius: 0px;
   }
 }
 


### PR DESCRIPTION
Found this awesome less file and went to use it only to find a small bug. When using different sized input groups where the typeahead element is not the first, last, or only child of the group, the typeahead input will have a border-radius on every corner.

Eg, the left and right are `.input-group-sm` and `.input-group-lg` respectfully and if you look closely, you can see the text input has all rounded corners:
![2014-01-26--1390745995_1126x72_scrot](https://f.cloud.github.com/assets/94542/2004938/a1117f5c-86c9-11e3-9d41-f8345c03c18c.png)

This should hopefully fix that.
