### PR TITLE
Update typeahead.less

### DIFF
--- a/typeahead.less
+++ b/typeahead.less
@@ -100,7 +100,6 @@
 //particular style for each other
 .twitter-typeahead .tt-hint {
   color: @text-muted;//color - hint
-  z-index: 1;
   border: 1px solid transparent;
 }
 .twitter-typeahead .tt-query {
@@ -147,7 +146,7 @@
     color: @dropdown-link-color;
     white-space: nowrap;
 
-    &.tt-is-under-cursor {
+    &.tt-cursor {
       //item selected
       text-decoration: none;
       outline: 0;


### PR DESCRIPTION
Updated name of '.tt-is-under-cursor' to '.tt-cursor'
Removed z-index from '.twitter-typeahead .tt-hint'

Now it should be compatible with the latest version of typeahead.

PS. sorry for duplicate patches, im new to github
