### PR TITLE
fix a problem where input is located inside form

### DIFF
--- a/typeahead.less
+++ b/typeahead.less
@@ -88,6 +88,7 @@
 //particular style for each other
 .twitter-typeahead .tt-hint {
   color: @text-muted;//color - hint
+  background: transparent;
 }
 .twitter-typeahead .tt-input {
   z-index: 2;


### PR DESCRIPTION
When input is located inside form, it appears disabled due to .tt-hint is readonly.
