### PR TITLE
Rename .tt-dropdown-menu to .tt-menu

### DIFF
--- a/typeahead.css
+++ b/typeahead.css
@@ -145,7 +145,7 @@ fieldset[disabled] .twitter-typeahead .tt-input {
   cursor: not-allowed;
   background-color: #eeeeee !important;
 }
-.tt-dropdown-menu {
+.tt-menu {
   position: absolute;
   top: 100%;
   left: 0;
@@ -166,7 +166,7 @@ fieldset[disabled] .twitter-typeahead .tt-input {
   *border-right-width: 2px;
   *border-bottom-width: 2px;
 }
-.tt-dropdown-menu .tt-suggestion {
+.tt-menu .tt-suggestion {
   display: block;
   padding: 3px 20px;
   clear: both;
@@ -175,15 +175,15 @@ fieldset[disabled] .twitter-typeahead .tt-input {
   color: #333333;
   white-space: nowrap;
 }
-.tt-dropdown-menu .tt-suggestion.tt-cursor {
+.tt-menu .tt-suggestion.tt-cursor {
   text-decoration: none;
   outline: 0;
   background-color: #f5f5f5;
   color: #262626;
 }
-.tt-dropdown-menu .tt-suggestion.tt-cursor a {
+.tt-menu .tt-suggestion.tt-cursor a {
   color: #262626;
 }
-.tt-dropdown-menu .tt-suggestion p {
+.tt-menu .tt-suggestion p {
   margin: 0;
 }

--- a/typeahead.less
+++ b/typeahead.less
@@ -105,7 +105,7 @@
 }
 
 //dropdown styles
-.tt-dropdown-menu {
+.tt-menu {
   //dropdown menu
   position: absolute;
   top: 100%;


### PR DESCRIPTION
Rename .tt-dropdown-menu to .tt-menu for compatibility with typeahead.js v0.11.1, like mentioned in #22
