### PR TITLE
Update typeahead bower dependency to 0.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   ],
   "dependencies": {
     "bootstrap": "~3.1.0",
-    "typeahead.js": "~0.10.0"
+    "typeahead.js": "~0.11.1"
   },
   "ignore":[
     "bootstrap",


### PR DESCRIPTION
While #25 added support for typeahead.js 0.11, `bower install` still
reported a version conflict when the parent project explicitly depended
on typeahead 0.11. This fixes that.
